### PR TITLE
Move `beep.Silence` to `generators.Silence`

### DIFF
--- a/buffer_test.go
+++ b/buffer_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/gopxl/beep"
+	"github.com/gopxl/beep/generators"
 )
 
 func TestFormatEncodeDecode(t *testing.T) {
@@ -75,7 +76,7 @@ func TestBufferAppendPop(t *testing.T) {
 
 	for format := range formats {
 		b := beep.NewBuffer(format)
-		b.Append(beep.Silence(768))
+		b.Append(generators.Silence(768))
 		if b.Len() != 768 {
 			t.Fatalf("buffer length isn't equal to appended stream length: expected: %v, actual: %v (NumChannels: %v)", 768, b.Len(), format.NumChannels)
 		}

--- a/generators/silence.go
+++ b/generators/silence.go
@@ -5,19 +5,27 @@ import "github.com/gopxl/beep"
 // Silence returns a Streamer which streams num samples of silence. If num is negative, silence is
 // streamed forever.
 func Silence(num int) beep.Streamer {
+	if num < 0 {
+		return beep.StreamerFunc(func(samples [][2]float64) (m int, ok bool) {
+			for i := range samples {
+				samples[i] = [2]float64{}
+			}
+			return len(samples), true
+		})
+	}
+
 	return beep.StreamerFunc(func(samples [][2]float64) (n int, ok bool) {
-		if num == 0 {
+		if num <= 0 {
 			return 0, false
 		}
-		if 0 < num && num < len(samples) {
+		if num < len(samples) {
 			samples = samples[:num]
 		}
 		for i := range samples {
 			samples[i] = [2]float64{}
 		}
-		if num > 0 {
-			num -= len(samples)
-		}
+		num -= len(samples)
+
 		return len(samples), true
 	})
 }

--- a/generators/silence.go
+++ b/generators/silence.go
@@ -1,0 +1,23 @@
+package generators
+
+import "github.com/gopxl/beep"
+
+// Silence returns a Streamer which streams num samples of silence. If num is negative, silence is
+// streamed forever.
+func Silence(num int) beep.Streamer {
+	return beep.StreamerFunc(func(samples [][2]float64) (n int, ok bool) {
+		if num == 0 {
+			return 0, false
+		}
+		if 0 < num && num < len(samples) {
+			samples = samples[:num]
+		}
+		for i := range samples {
+			samples[i] = [2]float64{}
+		}
+		if num > 0 {
+			num -= len(samples)
+		}
+		return len(samples), true
+	})
+}

--- a/generators/silence_test.go
+++ b/generators/silence_test.go
@@ -1,0 +1,30 @@
+package generators_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/gopxl/beep/generators"
+	"github.com/gopxl/beep/internal/testtools"
+)
+
+func TestSilence_StreamsFiniteSamples(t *testing.T) {
+	s := generators.Silence(100)
+
+	got := testtools.CollectNum(200, s)
+	assert.Equal(t, make([][2]float64, 100), got)
+
+	got = testtools.CollectNum(200, s)
+	assert.Len(t, got, 0)
+}
+
+func TestSilence_StreamsInfiniteSamples(t *testing.T) {
+	s := generators.Silence(-1)
+
+	got := testtools.CollectNum(200, s)
+	assert.Equal(t, make([][2]float64, 200), got)
+
+	got = testtools.CollectNum(200, s)
+	assert.Equal(t, make([][2]float64, 200), got)
+}

--- a/streamers.go
+++ b/streamers.go
@@ -2,6 +2,8 @@ package beep
 
 // Silence returns a Streamer which streams num samples of silence. If num is negative, silence is
 // streamed forever.
+//
+// Deprecated: beep.Silence has been moved to generators.Silence
 func Silence(num int) Streamer {
 	return StreamerFunc(func(samples [][2]float64) (n int, ok bool) {
 		if num == 0 {

--- a/wav/encode_test.go
+++ b/wav/encode_test.go
@@ -1,10 +1,13 @@
 package wav
 
 import (
+	"testing"
+
 	"github.com/gopxl/beep"
+	"github.com/gopxl/beep/generators"
+
 	"github.com/orcaman/writerseeker"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestEncode(t *testing.T) {
@@ -14,7 +17,7 @@ func TestEncode(t *testing.T) {
 		Precision:   2,
 	}
 	var w writerseeker.WriterSeeker
-	var s = beep.Silence(5)
+	var s = generators.Silence(5)
 
 	err := Encode(&w, s, f)
 	if err != nil {


### PR DESCRIPTION
- Moved the Silence function to the generators subpackage. The old function is kept intact but with a deprecation notice. Can be removed when we want to move to a new major version.
- Tested and optimized the function while I'm at it.