### PR TITLE
Fix speaker buffer size

### DIFF
--- a/speaker/speaker.go
+++ b/speaker/speaker.go
@@ -39,7 +39,7 @@ func Init(sampleRate beep.SampleRate, bufferSize int) error {
 		SampleRate:   int(sampleRate),
 		ChannelCount: channelCount,
 		Format:       otoFormat,
-		BufferSize:   sampleRate.D(bufferSize),
+		BufferSize:   0, // use the default
 	})
 	if err != nil {
 		return errors.Wrap(err, "failed to initialize speaker")
@@ -47,6 +47,7 @@ func Init(sampleRate beep.SampleRate, bufferSize int) error {
 	<-readyChan
 
 	player = context.NewPlayer(newReaderFromStreamer(&mixer))
+	player.SetBufferSize(bufferSize * bytesPerSample)
 	player.Play()
 
 	return nil


### PR DESCRIPTION
Resolves #133

This bug was introduced during the Oto version upgrade. I believed the buffer size setting had moved from the player to the context because the function signatures had changed. See [this commit](https://github.com/gopxl/beep/commit/5fefa491fdb0ba5eba5854f06fbd3cce91f4f9f2).  This wasn't the case though. The current PR fixes this.