### PR TITLE
Fix halved sample value for 16/24bit wav audio

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -131,11 +131,11 @@ func floatToSigned(precision int, x float64) uint64 {
 		compl := uint64(-x * math.Exp2(float64(precision)*8-1))
 		return uint64(1<<uint(precision*8)) - compl
 	}
-	return uint64(x * math.Exp2(float64(precision)*8-1))
+	return uint64(math.Min(x*math.Exp2(float64(precision)*8-1), math.Exp2(float64(precision)*8-1)-1))
 }
 
 func floatToUnsigned(precision int, x float64) uint64 {
-	return uint64((x + 1) / 2 * math.Exp2(float64(precision)*8))
+	return uint64(math.Min((x+1)/2*math.Exp2(float64(precision)*8), math.Exp2(float64(precision)*8)-1))
 }
 
 func signedToFloat(precision int, xUint64 uint64) float64 {

--- a/buffer.go
+++ b/buffer.go
@@ -128,26 +128,26 @@ func decodeFloat(signed bool, precision int, p []byte) (x float64, n int) {
 
 func floatToSigned(precision int, x float64) uint64 {
 	if x < 0 {
-		compl := uint64(-x * (math.Exp2(float64(precision)*8-1) - 1))
+		compl := uint64(-x * math.Exp2(float64(precision)*8-1))
 		return uint64(1<<uint(precision*8)) - compl
 	}
-	return uint64(x * (math.Exp2(float64(precision)*8-1) - 1))
+	return uint64(x * math.Exp2(float64(precision)*8-1))
 }
 
 func floatToUnsigned(precision int, x float64) uint64 {
-	return uint64((x + 1) / 2 * (math.Exp2(float64(precision)*8) - 1))
+	return uint64((x + 1) / 2 * math.Exp2(float64(precision)*8))
 }
 
 func signedToFloat(precision int, xUint64 uint64) float64 {
 	if xUint64 >= 1<<uint(precision*8-1) {
 		compl := 1<<uint(precision*8) - xUint64
-		return -float64(int64(compl)) / (math.Exp2(float64(precision)*8-1) - 1)
+		return -float64(int64(compl)) / math.Exp2(float64(precision)*8-1)
 	}
-	return float64(int64(xUint64)) / (math.Exp2(float64(precision)*8-1) - 1)
+	return float64(int64(xUint64)) / math.Exp2(float64(precision)*8-1)
 }
 
 func unsignedToFloat(precision int, xUint64 uint64) float64 {
-	return float64(xUint64)/(math.Exp2(float64(precision)*8)-1)*2 - 1
+	return float64(xUint64)/(math.Exp2(float64(precision)*8))*2 - 1
 }
 
 func norm(x float64) float64 {

--- a/wav/decode.go
+++ b/wav/decode.go
@@ -230,25 +230,25 @@ func (d *decoder) Stream(samples [][2]float64) (n int, ok bool) {
 		}
 	case d.h.BitsPerSample == 16 && d.h.NumChans == 1:
 		for i, j := 0, 0; i <= n-bytesPerFrame; i, j = i+bytesPerFrame, j+1 {
-			val := float64(int16(p[i+0])+int16(p[i+1])*(1<<8)) / (1<<16 - 1)
+			val := float64(int16(p[i+0])+int16(p[i+1])*(1<<8)) / (1<<15)
 			samples[j][0] = val
 			samples[j][1] = val
 		}
 	case d.h.BitsPerSample == 16 && d.h.NumChans >= 2:
 		for i, j := 0, 0; i <= n-bytesPerFrame; i, j = i+bytesPerFrame, j+1 {
-			samples[j][0] = float64(int16(p[i+0])+int16(p[i+1])*(1<<8)) / (1<<16 - 1)
-			samples[j][1] = float64(int16(p[i+2])+int16(p[i+3])*(1<<8)) / (1<<16 - 1)
+			samples[j][0] = float64(int16(p[i+0])+int16(p[i+1])*(1<<8)) / (1<<15)
+			samples[j][1] = float64(int16(p[i+2])+int16(p[i+3])*(1<<8)) / (1<<15)
 		}
 	case d.h.BitsPerSample == 24 && d.h.NumChans == 1:
 		for i, j := 0, 0; i <= n-bytesPerFrame; i, j = i+bytesPerFrame, j+1 {
-			val := float64((int32(p[i+0])<<8)+(int32(p[i+1])<<16)+(int32(p[i+2])<<24)) / (1 << 8) / (1<<24 - 1)
+			val := float64((int32(p[i+0])<<8)+(int32(p[i+1])<<16)+(int32(p[i+2])<<24)) / (1 << 8) / (1<<23)
 			samples[j][0] = val
 			samples[j][1] = val
 		}
 	case d.h.BitsPerSample == 24 && d.h.NumChans >= 2:
 		for i, j := 0, 0; i <= n-bytesPerFrame; i, j = i+bytesPerFrame, j+1 {
-			samples[j][0] = float64((int32(p[i+0])<<8)+(int32(p[i+1])<<16)+(int32(p[i+2])<<24)) / (1 << 8) / (1<<24 - 1)
-			samples[j][1] = float64((int32(p[i+3])<<8)+(int32(p[i+4])<<16)+(int32(p[i+5])<<24)) / (1 << 8) / (1<<24 - 1)
+			samples[j][0] = float64((int32(p[i+0])<<8)+(int32(p[i+1])<<16)+(int32(p[i+2])<<24)) / (1 << 8) / (1<<23)
+			samples[j][1] = float64((int32(p[i+3])<<8)+(int32(p[i+4])<<16)+(int32(p[i+5])<<24)) / (1 << 8) / (1<<23)
 		}
 	}
 	d.pos += int32(n)

--- a/wav/decode.go
+++ b/wav/decode.go
@@ -225,8 +225,8 @@ func (d *decoder) Stream(samples [][2]float64) (n int, ok bool) {
 		}
 	case d.h.BitsPerSample == 8 && d.h.NumChans >= 2:
 		for i, j := 0, 0; i <= n-bytesPerFrame; i, j = i+bytesPerFrame, j+1 {
-			samples[j][0] = float64(p[i+0])/(1<<8-1)*2 - 1
-			samples[j][1] = float64(p[i+1])/(1<<8-1)*2 - 1
+			samples[j][0] = float64(p[i+0])/(1<<8)*2 - 1
+			samples[j][1] = float64(p[i+1])/(1<<8)*2 - 1
 		}
 	case d.h.BitsPerSample == 16 && d.h.NumChans == 1:
 		for i, j := 0, 0; i <= n-bytesPerFrame; i, j = i+bytesPerFrame, j+1 {

--- a/wav/decode.go
+++ b/wav/decode.go
@@ -219,7 +219,7 @@ func (d *decoder) Stream(samples [][2]float64) (n int, ok bool) {
 	switch {
 	case d.h.BitsPerSample == 8 && d.h.NumChans == 1:
 		for i, j := 0, 0; i <= n-bytesPerFrame; i, j = i+bytesPerFrame, j+1 {
-			val := float64(p[i])/(1<<8-1)*2 - 1
+			val := float64(p[i])/(1<<8)*2 - 1
 			samples[j][0] = val
 			samples[j][1] = val
 		}
@@ -230,25 +230,25 @@ func (d *decoder) Stream(samples [][2]float64) (n int, ok bool) {
 		}
 	case d.h.BitsPerSample == 16 && d.h.NumChans == 1:
 		for i, j := 0, 0; i <= n-bytesPerFrame; i, j = i+bytesPerFrame, j+1 {
-			val := float64(int16(p[i+0])+int16(p[i+1])*(1<<8)) / (1<<15)
+			val := float64(int16(p[i+0])+int16(p[i+1])*(1<<8)) / (1 << 15)
 			samples[j][0] = val
 			samples[j][1] = val
 		}
 	case d.h.BitsPerSample == 16 && d.h.NumChans >= 2:
 		for i, j := 0, 0; i <= n-bytesPerFrame; i, j = i+bytesPerFrame, j+1 {
-			samples[j][0] = float64(int16(p[i+0])+int16(p[i+1])*(1<<8)) / (1<<15)
-			samples[j][1] = float64(int16(p[i+2])+int16(p[i+3])*(1<<8)) / (1<<15)
+			samples[j][0] = float64(int16(p[i+0])+int16(p[i+1])*(1<<8)) / (1 << 15)
+			samples[j][1] = float64(int16(p[i+2])+int16(p[i+3])*(1<<8)) / (1 << 15)
 		}
 	case d.h.BitsPerSample == 24 && d.h.NumChans == 1:
 		for i, j := 0, 0; i <= n-bytesPerFrame; i, j = i+bytesPerFrame, j+1 {
-			val := float64((int32(p[i+0])<<8)+(int32(p[i+1])<<16)+(int32(p[i+2])<<24)) / (1 << 8) / (1<<23)
+			val := float64((int32(p[i+0])<<8)+(int32(p[i+1])<<16)+(int32(p[i+2])<<24)) / (1 << 8) / (1 << 23)
 			samples[j][0] = val
 			samples[j][1] = val
 		}
 	case d.h.BitsPerSample == 24 && d.h.NumChans >= 2:
 		for i, j := 0, 0; i <= n-bytesPerFrame; i, j = i+bytesPerFrame, j+1 {
-			samples[j][0] = float64((int32(p[i+0])<<8)+(int32(p[i+1])<<16)+(int32(p[i+2])<<24)) / (1 << 8) / (1<<23)
-			samples[j][1] = float64((int32(p[i+3])<<8)+(int32(p[i+4])<<16)+(int32(p[i+5])<<24)) / (1 << 8) / (1<<23)
+			samples[j][0] = float64((int32(p[i+0])<<8)+(int32(p[i+1])<<16)+(int32(p[i+2])<<24)) / (1 << 8) / (1 << 23)
+			samples[j][1] = float64((int32(p[i+3])<<8)+(int32(p[i+4])<<16)+(int32(p[i+5])<<24)) / (1 << 8) / (1 << 23)
 		}
 	}
 	d.pos += int32(n)


### PR DESCRIPTION
The original code is mapping sample value of 16/24bit wav audio to [-0.5xxx,0.5].
This commit changes the range to [-1,1).
