### PR TITLE
Rewrite resampler

### DIFF
--- a/examples/speedy-player/main.go
+++ b/examples/speedy-player/main.go
@@ -7,6 +7,7 @@ import (
 	"unicode"
 
 	"github.com/gdamore/tcell/v2"
+
 	"github.com/gopxl/beep"
 	"github.com/gopxl/beep/effects"
 	"github.com/gopxl/beep/mp3"
@@ -128,13 +129,21 @@ func (ap *audioPanel) handle(event tcell.Event) (changed, quit bool) {
 
 		case 'z':
 			speaker.Lock()
-			ap.resampler.SetRatio(ap.resampler.Ratio() * 15 / 16)
+			newRatio := ap.resampler.Ratio() * 15 / 16
+			if newRatio < 0.001 {
+				newRatio = 0.001
+			}
+			ap.resampler.SetRatio(newRatio)
 			speaker.Unlock()
 			return true, false
 
 		case 'x':
 			speaker.Lock()
-			ap.resampler.SetRatio(ap.resampler.Ratio() * 16 / 15)
+			newRatio := ap.resampler.Ratio() * 16 / 15
+			if newRatio > 100 {
+				newRatio = 100
+			}
+			ap.resampler.SetRatio(newRatio)
 			speaker.Unlock()
 			return true, false
 		}

--- a/resample.go
+++ b/resample.go
@@ -68,7 +68,7 @@ func ResampleRatio(quality int, ratio float64, s Streamer) *Resampler {
 // changing of the resampling ratio, which can be useful for dynamically changing the speed of
 // streaming.
 type Resampler struct {
-	s          Streamer     // the orignal streamer
+	s          Streamer     // the original streamer
 	ratio      float64      // old sample rate / new sample rate
 	buf1, buf2 [][2]float64 // buf1 contains previous buf2, new data goes into buf2, buf1 is because interpolation might require old samples
 	pts        []point      // pts is for points used for interpolation

--- a/resample.go
+++ b/resample.go
@@ -58,9 +58,17 @@ func ResampleRatio(quality int, ratio float64, s Streamer) *Resampler {
 		buf1:  make([][2]float64, resamplerSingleBufferSize),
 		buf2:  make([][2]float64, resamplerSingleBufferSize),
 		pts:   make([]point, quality*2),
-		off:   -resamplerSingleBufferSize,
-		pos:   0.0,
-		end:   math.MaxInt,
+		// The initial value of `off` is set so that the current position is just behind the end
+		// of buf2:
+		//   current position (0) - len(buf2) = -resamplerSingleBufferSize
+		// When the Stream() method is called for the first time, it will determine that neither
+		// buf1 nor buf2 contain the required samples because they are both in the past relative to
+		// the chosen `off` value. As a result, buf2 will be filled with samples, and `off` will be
+		// incremented by resamplerSingleBufferSize, making `off` equal to 0. This will align the
+		// start of buf2 with the current position.
+		off: -resamplerSingleBufferSize,
+		pos: 0.0,
+		end: math.MaxInt,
 	}
 }
 

--- a/resample.go
+++ b/resample.go
@@ -57,7 +57,7 @@ func ResampleRatio(quality int, ratio float64, s Streamer) *Resampler {
 		ratio: ratio,
 		buf1:  make([][2]float64, resamplerSingleBufferSize),
 		buf2:  make([][2]float64, resamplerSingleBufferSize),
-		pts:   make([]point, quality*2+1),
+		pts:   make([]point, quality*2),
 		off:   -resamplerSingleBufferSize,
 		pos:   0,
 		end:   math.MaxInt,
@@ -85,8 +85,8 @@ func (r *Resampler) Stream(samples [][2]float64) (n int, ok bool) {
 
 		// Determine the quality*2 closest sample positions for the interpolation.
 		// The window has length len(r.pts) and is centered around wantPos.
-		windowStart := int(wantPos) - len(r.pts)/2   // (inclusive)
-		windowEnd := int(wantPos) + len(r.pts)/2 + 1 // (exclusive)
+		windowStart := int(wantPos) - (len(r.pts)-1)/2 // (inclusive)
+		windowEnd := int(wantPos) + len(r.pts)/2 + 1   // (exclusive)
 
 		// Prepare the buffers.
 		if windowEnd >= r.off+resamplerSingleBufferSize {

--- a/resample.go
+++ b/resample.go
@@ -57,7 +57,7 @@ func ResampleRatio(quality int, ratio float64, s Streamer) *Resampler {
 		ratio: ratio,
 		buf1:  make([][2]float64, resamplerSingleBufferSize),
 		buf2:  make([][2]float64, resamplerSingleBufferSize),
-		pts:   make([]point, quality*2),
+		pts:   make([]point, quality*2+1),
 		off:   -resamplerSingleBufferSize,
 		pos:   0,
 		end:   math.MaxInt,
@@ -85,9 +85,8 @@ func (r *Resampler) Stream(samples [][2]float64) (n int, ok bool) {
 
 		// Determine the quality*2 closest sample positions for the interpolation.
 		// The window has length len(r.pts) and is centered around wantPos.
-		// todo: check if this is actually centered around wantPos
-		windowStart := int(wantPos) - len(r.pts)/2 + 1 // (inclusive)
-		windowEnd := int(wantPos) + len(r.pts)/2 + 1   // (exclusive)
+		windowStart := int(wantPos) - len(r.pts)/2   // (inclusive)
+		windowEnd := int(wantPos) + len(r.pts)/2 + 1 // (exclusive)
 
 		// Prepare the buffers.
 		if windowEnd >= r.off+resamplerSingleBufferSize {

--- a/resample.go
+++ b/resample.go
@@ -94,11 +94,6 @@ func (r *Resampler) Stream(samples [][2]float64) (n int, ok bool) {
 			sn, _ := r.s.Stream(r.buf1)
 			if sn < len(r.buf1) {
 				r.end = r.off + resamplerSingleBufferSize + sn
-
-				// Zero the rest of the buffer
-				for i := sn; i < len(r.buf1); i++ {
-					r.buf1[i] = [2]float64{}
-				}
 			}
 
 			// Swap buffers.
@@ -112,12 +107,12 @@ func (r *Resampler) Stream(samples [][2]float64) (n int, ok bool) {
 		}
 
 		// Adjust the window to be within the available buffers.
-		//if windowStart < 0 {
-		//	windowStart = 0
-		//}
-		//if windowEnd > r.end {
-		//	windowEnd = r.end
-		//}
+		if windowStart < 0 {
+			windowStart = 0
+		}
+		if windowEnd > r.end {
+			windowEnd = r.end
+		}
 
 		// For each channel...
 		for c := range samples[0] {
@@ -143,7 +138,7 @@ func (r *Resampler) Stream(samples [][2]float64) (n int, ok bool) {
 
 			// Calculate the resampled sample using polynomial interpolation from the
 			// quality*2 closest samples.
-			samples[0][c] = lagrange(r.pts, wantPos)
+			samples[0][c] = lagrange(pts, wantPos)
 		}
 
 		samples = samples[1:]

--- a/resample_test.go
+++ b/resample_test.go
@@ -32,7 +32,7 @@ func TestResample(t *testing.T) {
 
 func resampleCorrect(quality int, old, new beep.SampleRate, p [][2]float64) [][2]float64 {
 	ratio := float64(old) / float64(new)
-	pts := make([]point, quality*2)
+	pts := make([]point, quality*2+1)
 	var resampled [][2]float64
 	for i := 0; ; i++ {
 		j := float64(i) * ratio
@@ -42,7 +42,7 @@ func resampleCorrect(quality int, old, new beep.SampleRate, p [][2]float64) [][2
 		var sample [2]float64
 		for c := range sample {
 			for k := range pts {
-				l := int(j) + k - len(pts)/2 + 1
+				l := int(j) + k - (len(pts)-1)/2
 				if l >= 0 && l < len(p) {
 					pts[k] = point{X: float64(l), Y: p[l][c]}
 				} else {

--- a/resample_test.go
+++ b/resample_test.go
@@ -49,7 +49,22 @@ func resampleCorrect(quality int, old, new beep.SampleRate, p [][2]float64) [][2
 					pts[k] = point{X: float64(l), Y: 0}
 				}
 			}
-			y := lagrange(pts[:], j)
+
+			startK := 0
+			for k, pt := range pts {
+				if pt.X >= 0 {
+					startK = k
+					break
+				}
+			}
+			endK := 0
+			for k, pt := range pts {
+				if pt.X < float64(len(p)) {
+					endK = k + 1
+				}
+			}
+
+			y := lagrange(pts[startK:endK], j)
 			sample[c] = y
 		}
 		resampled = append(resampled, sample)

--- a/resample_test.go
+++ b/resample_test.go
@@ -32,7 +32,7 @@ func TestResample(t *testing.T) {
 
 func resampleCorrect(quality int, old, new beep.SampleRate, p [][2]float64) [][2]float64 {
 	ratio := float64(old) / float64(new)
-	pts := make([]point, quality*2+1)
+	pts := make([]point, quality*2)
 	var resampled [][2]float64
 	for i := 0; ; i++ {
 		j := float64(i) * ratio


### PR DESCRIPTION
Fix for https://github.com/gopxl/beep/issues/20

Rewritten the `Resampler` to make the code easier to read & fix some bugs:
- When the source streamer didn't conform the `Streamer` interface by returning a drained signal & then returning samples again, the internal buffer could be resized and unsuitable to do the job causing an out of range panic. The new resampler keeps track of the end of the stream. When the end is reached, it will simply stay in a drained state.

- `SetRatio` with a big enough ratio could cause an out of range panic. This was because during the calculation of the new `pos`, the result was cast to an int. If the ratio was so big that this rounding down caused a different of more than the buffer size, the buffer would be indexed with a negative value. I don't expect any reasonable application to run into this error, but it's nice to not get panics when playing around with the speedy-player example. That said, I've added some limits to the values that can be selected in that example.
  
  `pos` is now a `float64`. I expect this to carry enough precision for most use-cases. Say you have a resample ratio of 1/6 (from 8000 to 48000), 48000 samples per seconds, 86400 seconds in a day, 365 days in a year, the number of unique values would be `6*48000*86400*365 = 9.082368×10^12`. `float64` has enough precision to hold a bit less than 16 decimal digits so even though I'm not entirely sure how much we need, there is still a bunch of wiggle room. `SetRatio` being more precise is probably good for the `Doppler` streamer. Less samples will be skipped over.

- `Stream` fetches new samples from the source streamer to fill the buffer when it detects that the samples needed for the interpolation are after the currently loaded buffers. However, when the ratio is larger than the buffer size, the needed samples could be more than one buffer away. I've replaced the `if` statement with a `for` loop so it keeps streaming samples until it reaches the right index. This solves another out of range panic.

I've added a fuzz test to confirm weird resample ratios don't cause panics anymore.

It seems that the doppler example is now easier to crash. But the `Doppler` streamer is experimental and was giving the resampler invalid ratios. It probably needs a rewrite as well, but that something for another day.