### PR TITLE
Rethinking the `beep.Streamer` interfaces

### DIFF
--- a/examples/doppler-stereo-room/main.go
+++ b/examples/doppler-stereo-room/main.go
@@ -8,6 +8,7 @@ import (
 	"unicode"
 
 	"github.com/gdamore/tcell/v2"
+
 	"github.com/gopxl/beep"
 	"github.com/gopxl/beep/effects"
 	"github.com/gopxl/beep/mp3"
@@ -157,15 +158,17 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Usage: %s song.mp3\n", os.Args[0])
 		os.Exit(1)
 	}
+
 	f, err := os.Open(os.Args[1])
 	if err != nil {
 		report(err)
 	}
+	defer f.Close()
+
 	streamer, format, err := mp3.Decode(f)
 	if err != nil {
 		report(err)
 	}
-	defer streamer.Close()
 
 	speaker.Init(format.SampleRate, format.SampleRate.N(time.Second/30))
 

--- a/examples/speedy-player/main.go
+++ b/examples/speedy-player/main.go
@@ -156,15 +156,17 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Usage: %s song.mp3\n", os.Args[0])
 		os.Exit(1)
 	}
+
 	f, err := os.Open(os.Args[1])
 	if err != nil {
 		report(err)
 	}
+	defer f.Close()
+
 	streamer, format, err := mp3.Decode(f)
 	if err != nil {
 		report(err)
 	}
-	defer streamer.Close()
 
 	speaker.Init(format.SampleRate, format.SampleRate.N(time.Second/30))
 

--- a/examples/tutorial/1-hello-beep/a/main.go
+++ b/examples/tutorial/1-hello-beep/a/main.go
@@ -15,12 +15,12 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	defer f.Close()
 
 	streamer, format, err := mp3.Decode(f)
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer streamer.Close()
 
 	speaker.Init(format.SampleRate, format.SampleRate.N(time.Second/10))
 

--- a/examples/tutorial/1-hello-beep/b/main.go
+++ b/examples/tutorial/1-hello-beep/b/main.go
@@ -15,12 +15,12 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	defer f.Close()
 
 	streamer, format, err := mp3.Decode(f)
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer streamer.Close()
 
 	sr := format.SampleRate * 2
 	speaker.Init(sr, sr.N(time.Second/10))

--- a/examples/tutorial/2-composing-and-controlling/a/main.go
+++ b/examples/tutorial/2-composing-and-controlling/a/main.go
@@ -16,12 +16,12 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	defer f.Close()
 
 	streamer, format, err := mp3.Decode(f)
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer streamer.Close()
 
 	speaker.Init(format.SampleRate, format.SampleRate.N(time.Second/10))
 

--- a/examples/tutorial/2-composing-and-controlling/b/main.go
+++ b/examples/tutorial/2-composing-and-controlling/b/main.go
@@ -16,12 +16,12 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	defer f.Close()
 
 	streamer, format, err := mp3.Decode(f)
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer streamer.Close()
 
 	speaker.Init(format.SampleRate, format.SampleRate.N(time.Second/10))
 

--- a/examples/tutorial/2-composing-and-controlling/c/main.go
+++ b/examples/tutorial/2-composing-and-controlling/c/main.go
@@ -16,12 +16,12 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	defer f.Close()
 
 	streamer, format, err := mp3.Decode(f)
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer streamer.Close()
 
 	speaker.Init(format.SampleRate, format.SampleRate.N(time.Second/10))
 

--- a/examples/tutorial/2-composing-and-controlling/d/main.go
+++ b/examples/tutorial/2-composing-and-controlling/d/main.go
@@ -17,12 +17,12 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	defer f.Close()
 
 	streamer, format, err := mp3.Decode(f)
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer streamer.Close()
 
 	speaker.Init(format.SampleRate, format.SampleRate.N(time.Second/10))
 

--- a/examples/tutorial/3-to-buffer-or-not-to-buffer/main.go
+++ b/examples/tutorial/3-to-buffer-or-not-to-buffer/main.go
@@ -26,7 +26,7 @@ func main() {
 
 	buffer := beep.NewBuffer(format)
 	buffer.Append(streamer)
-	streamer.Close()
+	f.Close()
 
 	for {
 		fmt.Print("Press [ENTER] to fire a gunshot! ")

--- a/interface.go
+++ b/interface.go
@@ -62,25 +62,6 @@ type StreamSeeker interface {
 	Seek(p int) error
 }
 
-// StreamCloser is a Streamer streaming from a resource which needs to be released, such as a file
-// or a network connection.
-type StreamCloser interface {
-	Streamer
-
-	// Close closes the Streamer and releases it's resources. Streamer will no longer stream any
-	// samples.
-	Close() error
-}
-
-// StreamSeekCloser is a union of StreamSeeker and StreamCloser.
-type StreamSeekCloser interface {
-	Streamer
-	Len() int
-	Position() int
-	Seek(p int) error
-	Close() error
-}
-
 // StreamerFunc is a Streamer created by simply wrapping a streaming function (usually a closure,
 // which encloses a time tracking variable). This sometimes simplifies creating new streamers.
 //

--- a/midi/decode.go
+++ b/midi/decode.go
@@ -35,11 +35,12 @@ type SoundFont struct {
 	sf *meltysynth.SoundFont
 }
 
-// Decode takes a ReadCloser containing audio data in MIDI format and a SoundFont to synthesize the sounds
+// Decode takes an io.Reader containing audio data in MIDI format and a SoundFont to synthesize the sounds
 // and returns a beep.StreamSeeker, which streams the audio.
 //
-// Decode closes the supplied ReadCloser.
-func Decode(rc io.ReadCloser, sf *SoundFont, sampleRate beep.SampleRate) (s beep.StreamSeeker, format beep.Format, err error) {
+// The io.Reader can be closed immediately after the call to midi.Decode because the data
+// will be loaded into memory.
+func Decode(r io.Reader, sf *SoundFont, sampleRate beep.SampleRate) (s beep.StreamSeeker, format beep.Format, err error) {
 	defer func() {
 		if err != nil {
 			err = errors.Wrap(err, "midi")
@@ -52,11 +53,7 @@ func Decode(rc io.ReadCloser, sf *SoundFont, sampleRate beep.SampleRate) (s beep
 		return nil, beep.Format{}, err
 	}
 
-	mf, err := meltysynth.NewMidiFile(rc)
-	if err != nil {
-		return nil, beep.Format{}, err
-	}
-	err = rc.Close()
+	mf, err := meltysynth.NewMidiFile(r)
 	if err != nil {
 		return nil, beep.Format{}, err
 	}

--- a/wav/decode.go
+++ b/wav/decode.go
@@ -7,24 +7,15 @@ import (
 	"io"
 	"time"
 
-	"github.com/gopxl/beep"
 	"github.com/pkg/errors"
+
+	"github.com/gopxl/beep"
 )
 
-// Decode takes a Reader containing audio data in WAVE format and returns a StreamSeekCloser,
+// Decode takes an io.Reader containing audio data in WAVE format and returns a StreamSeeker,
 // which streams that audio. The Seek method will panic if rc is not io.Seeker.
-//
-// Do not close the supplied Reader, instead, use the Close method of the returned
-// StreamSeekCloser when you want to release the resources.
-func Decode(r io.Reader) (s beep.StreamSeekCloser, format beep.Format, err error) {
+func Decode(r io.Reader) (s beep.StreamSeeker, format beep.Format, err error) {
 	d := decoder{r: r}
-	defer func() { // hacky way to always close r if an error occurred
-		if closer, ok := d.r.(io.Closer); ok {
-			if err != nil {
-				closer.Close()
-			}
-		}
-	}()
 
 	// READ "RIFF" header
 	if err := binary.Read(r, binary.LittleEndian, d.h.RiffMark[:]); err != nil {
@@ -283,15 +274,5 @@ func (d *decoder) Seek(p int) error {
 		return errors.Wrap(err, "wav: seek error")
 	}
 	d.pos = pos
-	return nil
-}
-
-func (d *decoder) Close() error {
-	if closer, ok := d.r.(io.Closer); ok {
-		err := closer.Close()
-		if err != nil {
-			return errors.Wrap(err, "wav")
-		}
-	}
 	return nil
 }


### PR DESCRIPTION
- Removed `beep.StreamCloser` and `beep.StreamSeekCloser`. These functions do not seem to add much value because the decoders that implement them only proxy the call to their source `io.Reader`. Besides, other `beep.Streamers` do not call `Close()` on their source streamers, so the user has to keep track of when to close the decoder or reader themselves in any case.

## TODO
- [ ] Update wiki
- [ ] Review docblocks