### PR TITLE
Fix Ogg/vorbis files are mono even if files have more channels

### DIFF
--- a/vorbis/decode.go
+++ b/vorbis/decode.go
@@ -67,14 +67,20 @@ func (d *decoder) Stream(samples [][2]float64) (n int, ok bool) {
 		leftChannelIndex = 0
 		rightChannelIndex = 0
 	case 2:
+		fallthrough
 	case 4:
 		leftChannelIndex = 0
 		rightChannelIndex = 1
 	case 3:
+		fallthrough
 	case 5:
+		fallthrough
 	case 6:
+		fallthrough
 	case 7:
+		fallthrough
 	case 8:
+		fallthrough
 	default:
 		leftChannelIndex = 0
 		rightChannelIndex = 2


### PR DESCRIPTION
Resolves https://github.com/gopxl/beep/issues/178

It's difficult to write a unit test this because ogg is a lossy format so I can't compare the samples to WAV. Suggestions welcome.

Can otherwise be tested by changing the speedy player to play ogg and obtaining a stereo (or more channels) ogg file to play through it.