### PR TITLE
Fix WAV pop sound after seek with unknown chunk in header

### DIFF
--- a/wav/decode.go
+++ b/wav/decode.go
@@ -129,7 +129,7 @@ func Decode(r io.Reader) (s beep.StreamSeekCloser, format beep.Format, err error
 			if err := binary.Read(r, binary.LittleEndian, trash); err != nil {
 				return nil, beep.Format{}, errors.Wrap(err, "wav: missing unknown chunk body")
 			}
-			d.hsz += 4 + fs //add size of (Unknown formtype + formsize)
+			d.hsz += 4 + 4 + fs //add size of (Unknown formtype + formsize + its trailing size)
 		}
 	}
 


### PR DESCRIPTION
Resolves #182

The pop sound was caused by an error in the header size calculation. When a WAV file contained a unknown chunk, first the chunk type (4 bytes) is red, then the size (4 bytes) and after that is the chunk data. The 4 bytes indicating the size weren't added to the total header size. When seeking to the beginning of the sample data, it would seek to a position in the header before the data. The header was then parsed as sample data, which caused the pop.

Test file:
[pop.zip](https://github.com/user-attachments/files/16912488/pop.zip)
Can be reproduced with the speedy-player by changing the decoded file type to WAV.