### PR TITLE
Upgrade checkout action

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Go
         uses: actions/setup-go@v5


### PR DESCRIPTION
Apparently https://github.com/gopxl/beep/pull/184 wasn't enough to get rid of the old node version warning when running an action.