### PR TITLE
chore(examples): update all examples to use Loop2 instead of deprecated Loop method

### DIFF
--- a/examples/tutorial/2-composing-and-controlling/b/main.go
+++ b/examples/tutorial/2-composing-and-controlling/b/main.go
@@ -25,8 +25,11 @@ func main() {
 
 	speaker.Init(format.SampleRate, format.SampleRate.N(time.Second/10))
 
-	loop := beep.Loop(3, streamer)
-	fast := beep.ResampleRatio(4, 5, loop)
+	loopStreamer, err := beep.Loop2(streamer, beep.LoopTimes(2))
+	if err != nil {
+		log.Fatal(err)
+	}
+	fast := beep.ResampleRatio(4, 5, loopStreamer)
 
 	done := make(chan bool)
 	speaker.Play(beep.Seq(fast, beep.Callback(func() {

--- a/examples/tutorial/2-composing-and-controlling/c/main.go
+++ b/examples/tutorial/2-composing-and-controlling/c/main.go
@@ -25,7 +25,12 @@ func main() {
 
 	speaker.Init(format.SampleRate, format.SampleRate.N(time.Second/10))
 
-	ctrl := &beep.Ctrl{Streamer: beep.Loop(-1, streamer), Paused: false}
+	loopStreamer, err := beep.Loop2(streamer)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	ctrl := &beep.Ctrl{Streamer: loopStreamer, Paused: false}
 	speaker.Play(ctrl)
 
 	for {

--- a/examples/tutorial/2-composing-and-controlling/d/main.go
+++ b/examples/tutorial/2-composing-and-controlling/d/main.go
@@ -25,8 +25,12 @@ func main() {
 	defer streamer.Close()
 
 	speaker.Init(format.SampleRate, format.SampleRate.N(time.Second/10))
+	loopStreamer, err := beep.Loop2(streamer)
+	if err != nil {
+		log.Fatal(err)
+	}
 
-	ctrl := &beep.Ctrl{Streamer: beep.Loop(-1, streamer), Paused: false}
+	ctrl := &beep.Ctrl{Streamer: loopStreamer, Paused: false}
 	volume := &effects.Volume{
 		Streamer: ctrl,
 		Base:     2,


### PR DESCRIPTION
Related [to](https://github.com/gopxl/beep/issues/200)